### PR TITLE
Add InterfaceMapping

### DIFF
--- a/sympde/expr/evaluation.py
+++ b/sympde/expr/evaluation.py
@@ -74,7 +74,7 @@ def zero_matrix(n_rows, n_cols):
 #==============================================================================
 def _get_size_and_starts(ls):
     n = 0
-    d_indices = {}
+    d_indices = OrderedDict()
     for x in ls:
         d_indices[x] = n
         if isinstance(x, ScalarTestFunction):
@@ -260,7 +260,7 @@ def _split_expr_over_interface(expr, interface, tests=None, trials=None):
     # ...
 
     int_expressions = []
-    bnd_expressions = {}
+    bnd_expressions = OrderedDict()
 
     # ...
     # we replace all jumps
@@ -272,7 +272,7 @@ def _split_expr_over_interface(expr, interface, tests=None, trials=None):
     # ...
 
     # ...
-    d_trials = {}
+    d_trials = OrderedDict()
     for u in trials:
         u_minus = minus(u)
         u_plus  = plus(u)
@@ -281,7 +281,7 @@ def _split_expr_over_interface(expr, interface, tests=None, trials=None):
 #        # TODO add sub for avg
 #        expr = expr.subs({jump(u): u_minus - u_plus})
 
-    d_tests  = {}
+    d_tests  = OrderedDict()
     for v in tests:
         v_minus = minus(v)
         v_plus  = plus(v)
@@ -496,14 +496,14 @@ class TerminalExpr(CalculusFunction):
             dim = expr.ldim
             domain = expr.domain
             if isinstance(domain, Union):
-                domain = list(domain._args)
+                domain = domain.as_tuple()
 
             elif not is_sequence(domain):
-                domain = [domain]
+                domain = (domain,)
             # ...
 
             # ...
-            d_expr = {}
+            d_expr = OrderedDict()
             for d in domain:
                 d_expr[d] = S.Zero
             # ...
@@ -528,7 +528,6 @@ class TerminalExpr(CalculusFunction):
                     for d in domain:
                         d_expr[d] += newexpr
                     # ...
-
             else:
                 newexpr = cls.eval(expr.expr, dim=dim)
                 newexpr = expand(newexpr)
@@ -554,7 +553,7 @@ class TerminalExpr(CalculusFunction):
             # ...
 
             # ...
-            d_new = {}
+            d_new = OrderedDict()
             for domain, newexpr in d_expr.items():
 
                 if newexpr != 0:
@@ -571,7 +570,7 @@ class TerminalExpr(CalculusFunction):
 
             # ...
             ls = []
-            d_all = {}
+            d_all = OrderedDict()
 
             # ... treating interfaces
             keys = [k for k in d_new.keys() if isinstance(k, Interface)]
@@ -609,7 +608,7 @@ class TerminalExpr(CalculusFunction):
             for domain in keys:
 
                 newexpr = d_new[domain]
-                d       = {interior : newexpr for interior in domain.as_tuple()}
+                d       = OrderedDict((interior, newexpr) for interior in domain.as_tuple())
                             # ...
                 for k, v in d.items():
                     if k in d_all.keys():
@@ -618,7 +617,7 @@ class TerminalExpr(CalculusFunction):
                     else:
                         d_all[k] = v
 
-            d = {}
+            d = OrderedDict()
 
             for k, v in d_new.items():
                 if not isinstance( k, (Interface, Union)):
@@ -690,7 +689,6 @@ class TerminalExpr(CalculusFunction):
                     for i in range(0, dim):
                         e += M[i] * n[i]
                     return e
-
             else:
                 raise ValueError('> Only traces of order 0 and 1 are available')
 
@@ -955,7 +953,7 @@ class TensorExpr(CalculusFunction):
             raise ValueError('Expecting one argument')
 
         expr = _args[0]
-        d_atoms = kwargs.pop('d_atoms', {})
+        d_atoms = kwargs.pop('d_atoms', OrderedDict())
         mapping = kwargs.pop('mapping', None)
 
         if isinstance(expr, Add):
@@ -1032,7 +1030,7 @@ class TensorExpr(CalculusFunction):
             variables  = list(terminal_expr.atoms(ScalarTestFunction))
             variables += list(terminal_expr.atoms(IndexedTestTrial))
 
-            d_atoms = {}
+            d_atoms = OrderedDict()
             for a in variables:
                 new = _split_test_function(a)
                 d_atoms[a] = new[a]

--- a/sympde/expr/expr.py
+++ b/sympde/expr/expr.py
@@ -54,16 +54,17 @@ def _get_domain(expr):
     if isinstance(expr, (DomainIntegral, BoundaryIntegral, InterfaceIntegral)):
         return expr.domain
 
-    elif isinstance(expr, (Add,Mul)):
-        domains = set()
+    elif isinstance(expr, (Add, Mul)):
+        domains = []
         for a in expr.args:
             a = _get_domain(a)
             if isinstance(a, Union):
-                domains = domains.union(a.args)
+                domains.extend(list(a.args))
             elif isinstance(a, BasicDomain):
-                domains = domains.union([a])
+                domains.append(a)
         if len(domains) == 1:
-            return tuple(domains)[0]
+            return domains[0]
+
         return Union(*domains)
 
 #==============================================================================

--- a/sympde/expr/expr.py
+++ b/sympde/expr/expr.py
@@ -104,6 +104,8 @@ class Integral(CalculusFunction):
 
     def __new__(cls, expr, domain, **options):
         # (Try to) sympify args first
+        if domain is None:
+            return sy_Zero()
 
         assert isinstance(domain, BasicDomain)
         return Integral.eval(expr, domain)
@@ -117,7 +119,7 @@ class Integral(CalculusFunction):
             raise TypeError('only Expr are accepted')
 
         if isinstance(expr, sy_Zero):
-            return sy_Zero
+            return sy_Zero()
 
         if isinstance(expr, Add):
             args = [Integral.eval(a, domain) for a in expr.args]
@@ -151,6 +153,18 @@ class DomainIntegral(AtomicExpr):
 
     def __rmul__(self, o):
         return DomainIntegral(self.expr*o, self.domain)
+
+    def __add__(self, o):
+        if o == 0:
+            return self
+        else:
+            return Add(self, o)
+
+    def __radd__(self, o):
+        if o == 0:
+            return self
+        else:
+            return Add(self, o)
 
     def __eq__(self, a):
         if isinstance(a, DomainIntegral):
@@ -216,6 +230,18 @@ class BoundaryIntegral(AtomicExpr):
     def __rmul__(self, o):
         return BoundaryIntegral(self.expr*o, self.domain)
 
+    def __add__(self, o):
+        if o == 0:
+            return self
+        else:
+            return Add(self, o)
+
+    def __radd__(self, o):
+        if o == 0:
+            return self
+        else:
+            return Add(self, o)
+
     def __eq__(self, a):
         if isinstance(a, BoundaryIntegral):
             eq = self.domain == a.domain
@@ -243,6 +269,18 @@ class InterfaceIntegral(AtomicExpr):
 
     def __rmul__(self, o):
         return InterfaceIntegral(self.expr*o, self.domain)
+
+    def __add__(self, o):
+        if o == 0:
+            return self
+        else:
+            return Add(self, o)
+
+    def __radd__(self, o):
+        if o == 0:
+            return self
+        else:
+            return Add(self, o)
 
     def __eq__(self, a):
         if isinstance(a, InterfaceIntegral):
@@ -309,7 +347,7 @@ class LinearForm(BasicForm):
 
         # Trivial case: null expression
         if expr == 0:
-            return sy_Zero
+            return sy_Zero()
 
         # Check that integral expression is given
         integral_types = DomainIntegral, BoundaryIntegral, InterfaceIntegral
@@ -401,7 +439,7 @@ class BilinearForm(BasicForm):
 
         # Trivial case: null expression
         if expr == 0:
-            return sy_Zero
+            return sy_Zero()
 
         # Check that integral expression is given
         integral_types = DomainIntegral, BoundaryIntegral, InterfaceIntegral
@@ -410,6 +448,7 @@ class BilinearForm(BasicForm):
 
         # Expand integral expression and sanitize arguments
         # TODO: why do we 'sanitize' here?
+
         expr = expand(expr)
         args = _sanitize_arguments(arguments, is_bilinear=True)
 

--- a/sympde/topology/basic.py
+++ b/sympde/topology/basic.py
@@ -113,8 +113,8 @@ class Union(BasicDomain):
         for union in unions:
             args += list(union.as_tuple())
 
-        # Sort domains by name
-        args = sorted(args, key=lambda x: x.name)
+        # remove duplicates and Sort domains by name
+        args = sorted(set(args), key=lambda x: x.name)
 
         # a. If the required Union contains no domains, return None;
         # b. If it contains a single domain, return the domain itself;

--- a/sympde/topology/basic.py
+++ b/sympde/topology/basic.py
@@ -115,7 +115,11 @@ class Union(BasicDomain):
             else:
                 new_args.append(i)
 
-        args = new_args
+        args = []
+        for i in new_args:
+            if i not in args:
+                args.append(i)
+
         # a. If the required Union contains no domains, return None;
         # b. If it contains a single domain, return the domain itself;
         # c. If it contains multiple domains, create a Union object.

--- a/sympde/topology/basic.py
+++ b/sympde/topology/basic.py
@@ -108,17 +108,10 @@ class Union(BasicDomain):
             raise ValueError(msg)
 
         # Flatten arguments into a single list of domains
-        new_args = []
-        for i in args:
-            if isinstance(i, Union):
-                new_args += list(i.as_tuple())
-            else:
-                new_args.append(i)
-
-        args = []
-        for i in new_args:
-            if i not in args:
-                args.append(i)
+        unions = [a for a in args if     isinstance(a, Union)]
+        args   = [a for a in args if not isinstance(a, Union)]
+        for union in unions:
+            args += list(union.as_tuple())
 
         # Sort domains by name
         args = sorted(args, key=lambda x: x.name)

--- a/sympde/topology/basic.py
+++ b/sympde/topology/basic.py
@@ -120,6 +120,9 @@ class Union(BasicDomain):
             if i not in args:
                 args.append(i)
 
+        # Sort domains by name
+        args = sorted(args, key=lambda x: x.name)
+
         # a. If the required Union contains no domains, return None;
         # b. If it contains a single domain, return the domain itself;
         # c. If it contains multiple domains, create a Union object.
@@ -161,14 +164,6 @@ class Union(BasicDomain):
         ls = [i for i in self.args]
         return tuple(ls)
 
-    def __eq__(self, a):
-        if isinstance(a, Union):
-            return set(self.as_tuple()) == set(a.as_tuple())
-        else:
-            return False
-
-    def __hash__(self):
-        return hash(self.as_tuple())
 #==============================================================================
 class ProductDomain(BasicDomain):
     def __new__(cls, *args, name=None):

--- a/sympde/topology/basic.py
+++ b/sympde/topology/basic.py
@@ -114,7 +114,7 @@ class Union(BasicDomain):
             args += list(union.as_tuple())
 
         # Sort domains by name
-        args = sorted(args, key=lambda x: x.name)
+        #args = sorted(args, key=lambda x: x.name)
 
         # a. If the required Union contains no domains, return None;
         # b. If it contains a single domain, return the domain itself;

--- a/sympde/topology/basic.py
+++ b/sympde/topology/basic.py
@@ -108,14 +108,14 @@ class Union(BasicDomain):
             raise ValueError(msg)
 
         # Flatten arguments into a single list of domains
-        unions = [a for a in args if     isinstance(a, Union)]
-        args   = [a for a in args if not isinstance(a, Union)]
-        for union in unions:
-            args += list(union.as_tuple())
+        new_args = []
+        for i in args:
+            if isinstance(i, Union):
+                new_args += list(i.as_tuple())
+            else:
+                new_args.append(i)
 
-        # Sort domains by name
-        #args = sorted(args, key=lambda x: x.name)
-
+        args = new_args
         # a. If the required Union contains no domains, return None;
         # b. If it contains a single domain, return the domain itself;
         # c. If it contains multiple domains, create a Union object.
@@ -157,6 +157,14 @@ class Union(BasicDomain):
         ls = [i for i in self.args]
         return tuple(ls)
 
+    def __eq__(self, a):
+        if isinstance(a, Union):
+            return set(self.as_tuple()) == set(a.as_tuple())
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(self.as_tuple())
 #==============================================================================
 class ProductDomain(BasicDomain):
     def __new__(cls, *args, name=None):

--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -57,10 +57,14 @@ class Domain(BasicDomain):
                 interiors = [interiors]
 
             else:
-                unions    = [i for i in interiors if isinstance(i, Union)]
-                interiors = [i for i in interiors if not isinstance(i, Union)]
-                for union in unions:
-                    interiors += list(union.as_tuple())
+                new_interiors = []
+                for i in interiors:
+                    if isinstance(i , Union):
+                        new_interiors += list(i.as_tuple())
+                    else:
+                        new_interiors.append(i)
+
+                interiors = new_interiors
 
                 if not all([isinstance(i, InteriorDomain) for i in interiors]):
                     raise TypeError('> all interiors must be of type InteriorDomain')
@@ -345,7 +349,7 @@ class Domain(BasicDomain):
                               boundaries=boundary,
                               connectivity=connectivity)
 
-    def join(self, other, name, bnd_minus, bnd_plus):
+    def join(self, other, name, bnd_minus=None, bnd_plus=None):
         # ... interiors
         interiors = [self.interior, other.interior]
         # ...
@@ -353,7 +357,8 @@ class Domain(BasicDomain):
         # ... connectivity
         connectivity = Connectivity()
         # TODO be careful with '|' in psydac
-        connectivity['{l}|{r}'.format(l=bnd_minus.domain.name, r=bnd_plus.domain.name)] = (bnd_minus, bnd_plus)
+        if bnd_minus and bnd_plus:
+            connectivity['{l}|{r}'.format(l=bnd_minus.domain.name, r=bnd_plus.domain.name)] = (bnd_minus, bnd_plus)
         for k,v in self.connectivity.items():
             connectivity[k] = v
 

--- a/sympde/topology/mapping.py
+++ b/sympde/topology/mapping.py
@@ -267,14 +267,14 @@ class InterfaceMapping(Mapping):
 
     Attributes
     ----------
-    M1 : Mapping
-        mapping on the negative direction of the interface
-    M2 : Mapping
-        mapping on the positive direction of the interface
+    minus : Mapping
+        the mapping on the negative direction of the interface
+    plus  : Mapping
+        the mapping on the positive direction of the interface
     """
 
-    def __new__(cls, M1, M2):
-        return Basic.__new__(cls, M1, M2)
+    def __new__(cls, minus, plus):
+        return Basic.__new__(cls, minus, plus)
 
     @property
     def minus(self):
@@ -286,7 +286,7 @@ class InterfaceMapping(Mapping):
 
     @property
     def is_analytical(self):
-        return self.minus.is_analytical
+        return self.minus.is_analytical and self.plus.is_analytical
 
     @property
     def rdim(self):

--- a/sympde/topology/mapping.py
+++ b/sympde/topology/mapping.py
@@ -260,6 +260,7 @@ class Mapping(BasicMapping):
     def _compute_hessian(self):
         raise NotImplementedError('TODO')
 
+#==============================================================================
 class InterfaceMapping(Mapping):
     """
     InterfaceMapping is used to represent a mapping in the interface.
@@ -271,23 +272,25 @@ class InterfaceMapping(Mapping):
     M2 : Mapping
         mapping on the positive direction of the interface
     """
+
     def __new__(cls, M1, M2):
         return Basic.__new__(cls, M1, M2)
+
     @property
-    def M1(self):
+    def minus(self):
         return self._args[0]
 
     @property
-    def M2(self):
+    def plus(self):
         return self._args[1]
 
     @property
     def is_analytical(self):
-        return self.M1.is_analytical
+        return self.minus.is_analytical
 
     @property
     def rdim(self):
-        return self.M1.rdim
+        return self.minus.rdim
 
 #==============================================================================
 class IdentityMapping(Mapping):
@@ -675,9 +678,9 @@ class LogicalExpr(CalculusFunction):
 
         elif isinstance(expr, dx):
             if expr.atoms(PlusInterfaceOperator):
-                M = M.M2
+                M = M.plus
             elif expr.atoms(MinusInterfaceOperator):
-                M = M.M1
+                M = M.minus
 
             arg = expr.args[0]
             arg = cls.eval(M, arg)
@@ -713,9 +716,9 @@ class LogicalExpr(CalculusFunction):
 
         elif isinstance(expr, dy):
             if expr.atoms(PlusInterfaceOperator):
-                M = M.M2
+                M = M.plus
             elif expr.atoms(MinusInterfaceOperator):
-                M = M.M1
+                M = M.minus
 
             arg = expr.args[0]
             arg = cls.eval(M, arg)
@@ -747,9 +750,9 @@ class LogicalExpr(CalculusFunction):
 
         elif isinstance(expr, dz):
             if expr.atoms(PlusInterfaceOperator):
-                M = M.M2
+                M = M.plus
             elif expr.atoms(MinusInterfaceOperator):
-                M = M.M1
+                M = M.minus
 
             arg = expr.args[0]
             arg = cls.eval(M, arg)
@@ -926,7 +929,7 @@ class SymbolicExpr(CalculusFunction):
         elif isinstance(expr, SymbolicMappingExpr):
             mapping = expr.mapping
             if isinstance(mapping, InterfaceMapping):
-                mapping = mapping.M1
+                mapping = mapping.minus
             name = '{name}_{mapping}'.format(name=expr._name,
                                              mapping=mapping)
 

--- a/sympde/topology/mapping.py
+++ b/sympde/topology/mapping.py
@@ -246,6 +246,16 @@ class Mapping(BasicMapping):
         raise NotImplementedError('TODO')
 
 class InterfaceMapping(Mapping):
+    """
+    InterfaceMapping is used to represent a mapping in the interface.
+
+    Attributes
+    ----------
+    M1 : Mapping
+        mapping on the negative direction of the interface
+    M2 : Mapping
+        mapping on the positive direction of the interface
+    """
     def __new__(cls, M1, M2):
         return Basic.__new__(cls, M1, M2)
     @property


### PR DESCRIPTION
InterfaceMapping is used to represent a mapping in the interface, it's needed in the case of two different mappings.
in this PR we have made the following changes : 
- Add InterfaceMapping class
- Use OrderedDict in TerminalExpr instead of Dict to preserve the order of the expressions
- Add AffineMapping
- Add the __add__ magic method in Integral classes 
