### PR TITLE
Delete MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include README.rst


### PR DESCRIPTION
The manifest is not needed when using a `pyproject.toml` file, and it should have been removed in the previous PR.