### PR TITLE
Fix bounds bug in `plot_3d_single_patch`

### DIFF
--- a/sympde/utilities/utils.py
+++ b/sympde/utilities/utils.py
@@ -222,7 +222,7 @@ def plot_3d_single_patch(patch, mapping, ax, refinement=15):
     full_00 = np.full((refinement, refinement), linspace_0[0])
     full_01 = np.full((refinement, refinement), linspace_0[-1])
     full_10 = np.full((refinement, refinement), linspace_1[0])
-    full_11 = np.full((refinement, refinement), linspace_0[-1])
+    full_11 = np.full((refinement, refinement), linspace_1[-1])
     full_20 = np.full((refinement, refinement), linspace_2[0])
     full_21 = np.full((refinement, refinement), linspace_2[-1])
 


### PR DESCRIPTION
This PR applies a one character fix in the function `plot_3d_single_patch` which would previously calculate the surface $\lbrace (x, y_{\text{max}}, z) | (x, z) \in [x_{\text{min}}, x_{\text{max}}] \times [z_{\text{min}}, z_{\text{max}}] \rbrace$ using $x_{\text{max}}$ instead of $y_{\text{max}}$.
