### PR TITLE
Add flag to ignore linearity errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sympde"
-version         = "0.18.1"
+version         = "0.18.2"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
 requires-python = ">= 3.8, < 3.12"

--- a/sympde/expr/expr.py
+++ b/sympde/expr/expr.py
@@ -351,11 +351,11 @@ class LinearForm(BasicForm):
         if not is_linear_expression(expr, args):
             print(expr)
             print(args)
-            msg = 'Expression is not linear w.r.t [{}]'.format(args)
-            if not ignore_linearity_errors:
-                raise UnconsistentLinearExpressionError(msg)
-            else:
+            msg = f'Expression is not linear w.r.t. [{args}]'
+            if ignore_linearity_errors:
                 print(msg)
+            else:
+                raise UnconsistentLinearExpressionError(msg)
 
         # Create new object of type LinearForm
         obj = Basic.__new__(cls, args, expr)
@@ -438,22 +438,20 @@ class BilinearForm(BasicForm):
 
         # Check linearity with respect to trial functions
         if not is_linear_expression(expr, trial_functions):
-            msg = ' Expression is not linear w.r.t trial functions {}'\
-                    .format(trial_functions)
-            if not ignore_linearity_errors:
-                raise UnconsistentLinearExpressionError(msg)
-            else:
+            msg = f'Expression is not linear w.r.t. trial functions [{trial_functions}]'
+            if ignore_linearity_errors:
                 print(msg)
+            else:
+                raise UnconsistentLinearExpressionError(msg)
 
 
         # Check linearity with respect to test functions
         if not is_linear_expression(expr, test_functions):
-            msg = ' Expression is not linear w.r.t test functions {}'\
-                    .format(test_functions)
-            if not ignore_linearity_errors:
-                raise UnconsistentLinearExpressionError(msg)
-            else:
+            msg = f'Expression is not linear w.r.t. test functions [{test_functions}]'
+            if ignore_linearity_errors:
                 print(msg)
+            else:
+                raise UnconsistentLinearExpressionError(msg)
 
         # Create new object of type BilinearForm
         obj = Basic.__new__(cls, args, expr)

--- a/sympde/expr/expr.py
+++ b/sympde/expr/expr.py
@@ -334,7 +334,7 @@ class Functional(BasicForm):
 class LinearForm(BasicForm):
     is_linear = True
 
-    def __new__(cls, arguments, expr, **options):
+    def __new__(cls, arguments, expr, ignore_linearity_errors=False, **options):
 
         # Trivial case: null expression
         if expr == 0:
@@ -349,8 +349,13 @@ class LinearForm(BasicForm):
 
         # Check linearity with respect to the given arguments
         if not is_linear_expression(expr, args):
+            print(expr)
+            print(args)
             msg = 'Expression is not linear w.r.t [{}]'.format(args)
-            raise UnconsistentLinearExpressionError(msg)
+            if not ignore_linearity_errors:
+                raise UnconsistentLinearExpressionError(msg)
+            else:
+                print(msg)
 
         # Create new object of type LinearForm
         obj = Basic.__new__(cls, args, expr)
@@ -414,7 +419,7 @@ class BilinearForm(BasicForm):
     is_bilinear = True
     _is_symmetric = None
 
-    def __new__(cls, arguments, expr, **options):
+    def __new__(cls, arguments, expr, ignore_linearity_errors=False, **options):
 
         # Trivial case: null expression
         if expr == 0:
@@ -435,13 +440,20 @@ class BilinearForm(BasicForm):
         if not is_linear_expression(expr, trial_functions):
             msg = ' Expression is not linear w.r.t trial functions {}'\
                     .format(trial_functions)
-            raise UnconsistentLinearExpressionError(msg)
+            if not ignore_linearity_errors:
+                raise UnconsistentLinearExpressionError(msg)
+            else:
+                print(msg)
+
 
         # Check linearity with respect to test functions
         if not is_linear_expression(expr, test_functions):
             msg = ' Expression is not linear w.r.t test functions {}'\
                     .format(test_functions)
-            raise UnconsistentLinearExpressionError(msg)
+            if not ignore_linearity_errors:
+                raise UnconsistentLinearExpressionError(msg)
+            else:
+                print(msg)
 
         # Create new object of type BilinearForm
         obj = Basic.__new__(cls, args, expr)


### PR DESCRIPTION
Add the flag `ignore_linearity_errors` to the constructors of `BilinearForm` and `LinearForm`.
Such a flag converts the error of the linearity check into a warning.
This is useful because the linearity check sometimes fails due to small roundoff errors.