### PR TITLE
Allow turning off linearity checks in bilinear and linear forms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sympde"
-version         = "0.18.2"
+version         = "0.18.3"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
 requires-python = ">= 3.8, < 3.12"

--- a/sympde/expr/expr.py
+++ b/sympde/expr/expr.py
@@ -334,7 +334,7 @@ class Functional(BasicForm):
 class LinearForm(BasicForm):
     is_linear = True
 
-    def __new__(cls, arguments, expr, ignore_linearity_errors=False, **options):
+    def __new__(cls, arguments, expr, check_linearity=True, ignore_linearity_errors=False, **options):
 
         # Trivial case: null expression
         if expr == 0:
@@ -348,7 +348,7 @@ class LinearForm(BasicForm):
         args = _sanitize_arguments(arguments, is_linear=True)
 
         # Check linearity with respect to the given arguments
-        if not is_linear_expression(expr, args):
+        if check_linearity and not is_linear_expression(expr, args):
             print(expr)
             print(args)
             msg = f'Expression is not linear w.r.t. [{args}]'
@@ -419,7 +419,7 @@ class BilinearForm(BasicForm):
     is_bilinear = True
     _is_symmetric = None
 
-    def __new__(cls, arguments, expr, ignore_linearity_errors=False, **options):
+    def __new__(cls, arguments, expr, check_linearity=True, ignore_linearity_errors=False, **options):
 
         # Trivial case: null expression
         if expr == 0:
@@ -437,7 +437,7 @@ class BilinearForm(BasicForm):
         trial_functions, test_functions = args
 
         # Check linearity with respect to trial functions
-        if not is_linear_expression(expr, trial_functions):
+        if check_linearity and not is_linear_expression(expr, trial_functions):
             msg = f'Expression is not linear w.r.t. trial functions [{trial_functions}]'
             if ignore_linearity_errors:
                 print(msg)
@@ -446,7 +446,7 @@ class BilinearForm(BasicForm):
 
 
         # Check linearity with respect to test functions
-        if not is_linear_expression(expr, test_functions):
+        if check_linearity and not is_linear_expression(expr, test_functions):
             msg = f'Expression is not linear w.r.t. test functions [{test_functions}]'
             if ignore_linearity_errors:
                 print(msg)


### PR DESCRIPTION
Add the boolean flag `check_linearity` to the constructors of `BilinearForm` and `LinearForm`.  The default value is `True`. If set to `False`, the linearity checks are turned off completely. This is different than the existing flag `ignore_linearity_errors`, which controls whether we get a warning or an error when the linearity check fails. 

The new flag might be useful when the expression in the bilinear or linear form is complicated, because then the linearity check calls the SymPy `Expr` method `.expand(deep=True)`, which is recursive and can take a very long time.
