### PR TITLE
Upgrade supported Python version to 3.12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 keywords     = ["math"]
 classifiers  = ["Programming Language :: Python :: 3"]
 dependencies = [
-    'sympy >= 1.5, <= 1.12',
+    'sympy >= 1.5, < 1.10',
     'h5py',
     'pytest',
     'pyyaml',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name            = "sympde"
 version         = "0.18.3"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
-requires-python = ">= 3.8, <= 3.12.2"
+requires-python = ">= 3.8, < 3.13"
 license         = {file = "LICENSE"}
 authors         = [{name = "Ahmed Ratnani", email = "ratnaniahmed@gmail.com"}]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name            = "sympde"
 version         = "0.18.3"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
-requires-python = ">= 3.8, < 3.12"
+requires-python = ">= 3.8, <= 3.12.2"
 license         = {file = "LICENSE"}
 authors         = [{name = "Ahmed Ratnani", email = "ratnaniahmed@gmail.com"}]
 maintainers = [
@@ -17,7 +17,7 @@ maintainers = [
 keywords     = ["math"]
 classifiers  = ["Programming Language :: Python :: 3"]
 dependencies = [
-    'sympy >= 1.5, < 1.10',
+    'sympy >= 1.5, <= 1.12',
     'h5py',
     'pytest',
     'pyyaml',


### PR DESCRIPTION
Address #106. On my local machine (Ubuntu 22.04) the `sympde` tests pass for `sympy 1.9` but fail for `sympy 1.10-1.12`.  Let's see if the CI picks up the same failures I've encountered.