### PR TITLE
Domain coordinates should be real

### DIFF
--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -750,7 +750,7 @@ class NCube(Domain):
             raise ValueError("Min coordinates must be smaller than max")
 
         coord_names = 'x1:{}'.format(dim + 1)
-        coordinates = symbols(coord_names)
+        coordinates = symbols(coord_names, real=True)
 
         # Choose which type to use:
         #   a) if dim <= 3, use Line, Square or Cube;

--- a/sympde/topology/tests/test_gallery.py
+++ b/sympde/topology/tests/test_gallery.py
@@ -4,7 +4,7 @@ from sympy.abc import x,y,z
 from sympy import Tuple
 from sympy import symbols
 
-x1, x2, x3 = symbols('x1, x2, x3')
+x1, x2, x3 = symbols('x1, x2, x3', real=True)
 
 from sympde.topology import Interval, ProductDomain, InteriorDomain, Domain
 from sympde.topology import Line, Square, Cube, NCubeInterior


### PR DESCRIPTION
At the moment the domain coordinates are Sympy symbols but we don't specify them to be real.

Consequently when we take the real part of a complex expression of the coordinates, the resulting symbolic expression includes the imaginary part of the coordinate and eventually Pyccel throws an error.

Besides, setting the symbols to real simplifies considerably the expressions.