### PR TITLE
adding test with numpy constants

### DIFF
--- a/sympde/topology/mapping.py
+++ b/sympde/topology/mapping.py
@@ -223,7 +223,7 @@ class Mapping(BasicMapping):
             constants_values = {a.name:Constant(a.name) for a in constants}
             # subs constants as Constant objects instead of Symbol
             constants_values.update( kwargs )
-            d = {a:constants_values[a.name] for a in constants}
+            d = {a:float(constants_values[a.name]) for a in constants}
             args = args.subs(d)
 
             obj._expressions = args

--- a/sympde/topology/mapping.py
+++ b/sympde/topology/mapping.py
@@ -84,6 +84,13 @@ def get_logical_test_function(u):
     el              = l_space.element(u.name)
     return el
 
+import numpy as np
+
+def numpy_to_native_python(a):
+    if isinstance(a, np.generic):
+        return a.item()
+    return a
+
 #==============================================================================
 class BasicCallableMapping(ABC):
     """
@@ -223,7 +230,7 @@ class Mapping(BasicMapping):
             constants_values = {a.name:Constant(a.name) for a in constants}
             # subs constants as Constant objects instead of Symbol
             constants_values.update( kwargs )
-            d = {a:float(constants_values[a.name]) for a in constants}
+            d = {a:numpy_to_native_python(constants_values[a.name]) for a in constants}
             args = args.subs(d)
 
             obj._expressions = args

--- a/sympde/topology/tests/test_mapping.py
+++ b/sympde/topology/tests/test_mapping.py
@@ -130,7 +130,7 @@ def test_mapping_2d_2():
     D      = F(domain)
 
 def test_AffineMapping():
-    print('============ test_mapping_2d_2 ==============')
+    print('============ test_AffineMapping ==============')
 
     dim   = 2
     alpha = np.pi/2

--- a/sympde/topology/tests/test_mapping.py
+++ b/sympde/topology/tests/test_mapping.py
@@ -1,11 +1,13 @@
 # coding: utf-8
 
+import numpy as np
+
 from sympy.core.containers import Tuple
 from sympy import Matrix
 from sympy.tensor import IndexedBase
 from sympy import symbols, simplify
 
-from sympde.topology import Mapping, MappedDomain
+from sympde.topology import Mapping, MappedDomain, AffineMapping
 from sympde.topology import dx, dy, dz
 from sympde.topology import dx1, dx2, dx3
 from sympde.topology import Domain
@@ -124,6 +126,23 @@ def test_mapping_2d_2():
 
     dim   = 2
     F      = Mapping('F', dim=dim)
+    domain = Domain('Omega', dim=dim)
+    D      = F(domain)
+
+def test_AffineMapping():
+    print('============ test_mapping_2d_2 ==============')
+
+    dim   = 2
+    alpha = np.pi/2
+    c1    = 0.2
+    c2    = 1.5
+
+    F =  AffineMapping(
+        name='F', dim=2, c1=c1, c2=c2,
+        a11=np.cos(alpha), a12=-np.sin(alpha),
+        a21=np.sin(alpha), a22=np.cos(alpha),
+    )
+
     domain = Domain('Omega', dim=dim)
     D      = F(domain)
 


### PR DESCRIPTION
On my machine these lines trigger an error when run with python3.12

```
    import numpy as np
    from sympde.topology import AffineMapping

    dim   = 2
    alpha = np.pi/2
    c1    = 0.2
    c2    = 1.5

    F =  AffineMapping(
        name='F', dim=2, c1=c1, c2=c2,
        a11=np.cos(alpha), a12=-np.sin(alpha),
        a21=np.sin(alpha), a22=np.cos(alpha),
    )
```
