### PR TITLE
reverting real coordinates

### DIFF
--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -839,7 +839,7 @@ class NCube(Domain):
             raise ValueError("Min coordinates must be smaller than max")
 
         coord_names = 'x1:{}'.format(dim + 1)
-        coordinates = symbols(coord_names)  # [MCP 24.07.2024] we should be able to pass real=True but requires additional testing as it breaks some calls to TerminalExpr 
+        coordinates = symbols(coord_names)  # [MCP 24.07.2024] we should be able to pass real=True but requires additional testing as it breaks some calls to TerminalExpr
 
         # Choose which type to use:
         #   a) if dim <= 3, use Line, Square or Cube;

--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -839,7 +839,7 @@ class NCube(Domain):
             raise ValueError("Min coordinates must be smaller than max")
 
         coord_names = 'x1:{}'.format(dim + 1)
-        coordinates = symbols(coord_names, real=True)
+        coordinates = symbols(coord_names)  # [MCP 24.07.2024] we should be able to pass real=True but requires additional testing as it breaks some calls to TerminalExpr 
 
         # Choose which type to use:
         #   a) if dim <= 3, use Line, Square or Cube;

--- a/sympde/topology/tests/test_gallery.py
+++ b/sympde/topology/tests/test_gallery.py
@@ -4,7 +4,7 @@ from sympy.abc import x,y,z
 from sympy import Tuple
 from sympy import symbols
 
-x1, x2, x3 = symbols('x1, x2, x3', real=True)
+x1, x2, x3 = symbols('x1, x2, x3')
 
 from sympde.topology import Interval, ProductDomain, InteriorDomain, Domain
 from sympde.topology import Line, Square, Cube, NCubeInterior


### PR DESCRIPTION
The PR #156 defined domain coordinates with real=True argument. This is probably justified but requires additional testing as it breaks some calls to TerminalExpr. Here this change is reverted, and a dedicated PR will be reopened later.