### PR TITLE
Unique API for single/multi-patch `Domain` objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sympde"
-version         = "0.19.0"
+version         = "0.19.1"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
 requires-python = ">= 3.8, < 3.13"

--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -193,12 +193,6 @@ class Domain(BasicDomain):
     def mappings(self) -> OrderedDict:
         return OrderedDict([(P.logical_domain, P.mapping)
                            for P in self.subdomains])
-        # if isinstance( self.interior, iterable_types):    
-        #     subdomains = self.interior
-        # else:
-        #     subdomains = [self.interior]
-        # return OrderedDict([(P.logical_domain, P.mapping)
-        #                    for P in subdomains])
 
     @property
     def logical_domain(self) -> Domain:

--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -6,7 +6,7 @@ import h5py
 import yaml
 import os
 
-from collections import abc
+from collections import abc, OrderedDict
 from typing import Union as TypeUnion, Optional, List, Dict, Iterable, TYPE_CHECKING
 # Union clashes with core.basic.Union
 
@@ -179,6 +179,26 @@ class Domain(BasicDomain):
     def mapping(self) -> Optional[Mapping]:
         """The mapping that maps the logical domain to the physical domain"""
         return self.args[3]
+
+    @property
+    def subdomains(self) -> tuple:
+        """returns subdomains as tuple of Domains"""
+        if isinstance( self.interior, iterable_types):    
+            subs = self.interior
+        else:
+            subs = [self.interior]
+        return tuple(subs)
+
+    @property
+    def mappings(self) -> OrderedDict:
+        return OrderedDict([(P.logical_domain, P.mapping)
+                           for P in self.subdomains])
+        # if isinstance( self.interior, iterable_types):    
+        #     subdomains = self.interior
+        # else:
+        #     subdomains = [self.interior]
+        # return OrderedDict([(P.logical_domain, P.mapping)
+        #                    for P in subdomains])
 
     @property
     def logical_domain(self) -> Domain:
@@ -480,6 +500,11 @@ class Domain(BasicDomain):
         assert isinstance(patches, (tuple, list))
         assert isinstance(connectivity, (tuple, list))
         assert isinstance(name, str)
+
+        if len(patches) == 1:
+            # single patch domain: return the patch
+            assert len(connectivity) == 0
+            return patches[0]
 
         assert all(p.dim==patches[0].dim for p in patches)
         dim = int(patches[0].dim)

--- a/sympde/topology/domain.py
+++ b/sympde/topology/domain.py
@@ -183,7 +183,7 @@ class Domain(BasicDomain):
     @property
     def subdomains(self) -> tuple:
         """returns subdomains as tuple of Domains"""
-        if isinstance( self.interior, iterable_types):    
+        if isinstance( self.interior, iterable_types):
             subs = self.interior
         else:
             subs = [self.interior]


### PR DESCRIPTION
In order to improve the compatibility between single and multi-patch domains, we add:

- `subdomains` and `mappings` attributes to the `Domain` class, which always return a tuple (fixes #171);
- the possibility of calling the `join` function (which usually creates multipatch domains) with a single patch.