### PR TITLE
Stop support of Python 3.8, add support of Python 3.13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,13 +9,13 @@ on:
     branches: [ master ]
 
 jobs:
-  Linux:
-
-    runs-on: ubuntu-latest
+  test:
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ ubuntu-latest, macos-latest ]
         python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.9, '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sympde"
-version         = "0.19.1"
+version         = "0.19.2"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
 requires-python = ">= 3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name            = "sympde"
 version         = "0.19.1"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
-requires-python = ">= 3.8, < 3.13"
+requires-python = ">= 3.9, < 3.13"
 license         = {file = "LICENSE"}
 authors         = [{name = "Ahmed Ratnani", email = "ratnaniahmed@gmail.com"}]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name            = "sympde"
 version         = "0.19.1"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
-requires-python = ">= 3.9, < 3.14"
+requires-python = ">= 3.9"
 license         = {file = "LICENSE"}
 authors         = [{name = "Ahmed Ratnani", email = "ratnaniahmed@gmail.com"}]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name            = "sympde"
 version         = "0.19.1"
 description     = "Symbolic calculus for partial differential equations (and variational forms)"
 readme          = "README.rst"
-requires-python = ">= 3.9, < 3.13"
+requires-python = ">= 3.9, < 3.14"
 license         = {file = "LICENSE"}
 authors         = [{name = "Ahmed Ratnani", email = "ratnaniahmed@gmail.com"}]
 maintainers = [


### PR DESCRIPTION
Fixes #176. On 7 October 2024:
* Python 3.8 reached end of life;
* Python 3.13 was first released.

See https://devguide.python.org/versions/ for reference.

Hence we drop here support for Python 3.8, and allow for installation with any Python version >= 3.9. Unit tests are now run with all Python versions between 3.9 and 3.13, on Ubuntu and macOS runners.